### PR TITLE
Fix blender crashing

### DIFF
--- a/yabee_libs/egg_writer.py
+++ b/yabee_libs/egg_writer.py
@@ -1737,7 +1737,7 @@ def write_out(fname, anims, from_actions, uv_img_as_tex, sep_anim, a_only,
         for obj in d:
             if obj not in old_data[d]:
                 # print("{} has {} users. Proceeding to clear.".format(obj.name, obj.users))
-                obj.user_clear()
+                # obj.user_clear()
                 try:
                     d.remove(obj, do_unlink=True)
                 except:


### PR DESCRIPTION
https://developer.blender.org/T49837
obj.user_clear() causes blender to crash with 
ERROR (bke.library): /build/blender-RL3axj/blender-2.82.a+dfsg/source/blender/blenkernel/intern/library.c:260 id_us_min: ID user decrement error: MAMaterial.001 (from '[Main]'): 0 <= 0